### PR TITLE
Fix missing null-terminating the string

### DIFF
--- a/main/badge/badge.c
+++ b/main/badge/badge.c
@@ -72,6 +72,7 @@ char* load_schedule_from_file() {
         return NULL;
     } 
     fread(data_buf, 1, file_size, fp);
+    data_buf[file_size] = '\0';  // Null-terminate the string
     fclose(fp);
     return data_buf;
 }


### PR DESCRIPTION
In the load_schedule_from_file function, after allocating memory with malloc(file_size + 1) and reading the file content with fread(), the function is missing a crucial step: null-terminating the string.

The buffer is not being null-terminated, which means when the JSON string is sent to the client, it may contain garbage data at the end, making it invalid JSON that cannot be parsed by the browser.

closes #1  