### PR TITLE
Fix LED collision between easter eggs and normal flashing

### DIFF
--- a/main/badge/led.h
+++ b/main/badge/led.h
@@ -36,4 +36,8 @@ void set_completed(void);
 
 void rainbow(void);
 
+void flash(int period, uint8_t fade_factor);
+
+void set_easter_egg_active(bool active);
+
 #endif // _LED_H

--- a/main/badge/version.c
+++ b/main/badge/version.c
@@ -1,3 +1,3 @@
-const char* GIT_REV="29b761f+";
+const char* GIT_REV="3f2c44c+";
 const char* GIT_TAG="";
-const char* GIT_BRANCH="main";
+const char* GIT_BRANCH="fix-led-collision";


### PR DESCRIPTION
- Add easter_egg_active flag to prevent LED task interference
- Block normal LED flashing during rainbow() and set_completed() execution
- Add set_easter_egg_active() function to control the blocking mechanism
- Ensure easter eggs run without interruption from the LED task
- LED task now checks easter_egg_active flag and waits when easter eggs are running

Closes #13